### PR TITLE
Fix export json when cropping

### DIFF
--- a/tests/utils_tests/test_annotation_export.py
+++ b/tests/utils_tests/test_annotation_export.py
@@ -1,0 +1,270 @@
+"""Tests for annotation export utilities."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from tras._label_file import LabelFile
+from tras.utils.annotation_export import export_annotations_json
+
+
+class MockShape:
+    """Mock shape object for testing."""
+    
+    def __init__(self, label="test", points=None, shape_type="polygon"):
+        self.label = label
+        self.points = points or []
+        self.group_id = None
+        self.description = ""
+        self.shape_type = shape_type
+        self.flags = {}
+        self.mask = None
+        self.other_data = {}
+
+
+class MockPoint:
+    """Mock point object for testing."""
+    
+    def __init__(self, x, y):
+        self._x = x
+        self._y = y
+    
+    def x(self):
+        return self._x
+    
+    def y(self):
+        return self._y
+
+
+class MockWindow:
+    """Mock window object for testing annotation export."""
+    
+    def __init__(self):
+        self.imagePath = "/test/image.png"
+        self.imageData = b"fake_image_data"
+        self.image = MagicMock()
+        self.image.height.return_value = 100
+        self.image.width.return_value = 200
+        self._config = {"store_data": True}
+        self.otherData = {}
+        self.sample_metadata = None
+        self.image_scale = None
+        self.pith_xy = None
+        self.labelList = []
+        self.flag_widget = MagicMock()
+        self.flag_widget.count.return_value = 0
+
+
+def test_export_empty_shapes():
+    """Test exporting with zero shapes."""
+    window = MockWindow()
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = Path(tmpdir) / "test.json"
+        export_annotations_json(window, output_file)
+        
+        # Verify file was created
+        assert output_file.exists()
+        
+        # Load and verify structure
+        label_file = LabelFile(str(output_file))
+        assert label_file.shapes == []
+        assert label_file.imagePath == "image.png"  # Relative path
+        assert label_file.imageData is not None
+
+
+def test_export_with_shapes():
+    """Test exporting with shapes."""
+    window = MockWindow()
+    
+    # Create mock shapes
+    shape1 = MockShape("ring1", [MockPoint(10, 20), MockPoint(30, 40)])
+    shape2 = MockShape("ring2", [MockPoint(50, 60), MockPoint(70, 80)])
+    
+    # Create mock label list items
+    item1 = MagicMock()
+    item1.shape.return_value = shape1
+    item2 = MagicMock()
+    item2.shape.return_value = shape2
+    
+    window.labelList = [item1, item2]
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = Path(tmpdir) / "test.json"
+        export_annotations_json(window, output_file)
+        
+        # Verify file was created
+        assert output_file.exists()
+        
+        # Load and verify
+        label_file = LabelFile(str(output_file))
+        assert len(label_file.shapes) == 2
+        assert label_file.shapes[0]["label"] == "ring1"
+        assert label_file.shapes[1]["label"] == "ring2"
+
+
+def test_export_preserves_preprocessing_info():
+    """Test that preprocessing info is preserved in export."""
+    window = MockWindow()
+    window.otherData = {
+        "preprocessing": {
+            "crop_rect": (10, 20, 100, 150),
+            "scale_factor": 0.8,
+            "background_removed": False,
+            "original_size": [200, 100],
+            "processed_size": [160, 80],
+        }
+    }
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = Path(tmpdir) / "test.json"
+        export_annotations_json(window, output_file)
+        
+        # Load and verify preprocessing info is present
+        label_file = LabelFile(str(output_file))
+        assert "preprocessing" in label_file.otherData
+        assert label_file.otherData["preprocessing"]["crop_rect"] == (10, 20, 100, 150)
+        assert label_file.otherData["preprocessing"]["scale_factor"] == 0.8
+
+
+def test_export_preserves_sample_metadata():
+    """Test that sample metadata is preserved in export."""
+    window = MockWindow()
+    window.sample_metadata = {
+        "harvested_year": 2023,
+        "sample_code": "TEST001",
+        "observation": "Test observation"
+    }
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = Path(tmpdir) / "test.json"
+        export_annotations_json(window, output_file)
+        
+        # Load and verify sample metadata is present
+        label_file = LabelFile(str(output_file))
+        assert "sample_metadata" in label_file.otherData
+        assert label_file.otherData["sample_metadata"]["harvested_year"] == 2023
+        assert label_file.otherData["sample_metadata"]["sample_code"] == "TEST001"
+
+
+def test_export_preserves_image_scale():
+    """Test that image scale is preserved in export."""
+    window = MockWindow()
+    window.image_scale = {
+        "value": 0.02,
+        "unit": "mm"
+    }
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = Path(tmpdir) / "test.json"
+        export_annotations_json(window, output_file)
+        
+        # Load and verify image scale is present
+        label_file = LabelFile(str(output_file))
+        assert "image_scale" in label_file.otherData
+        assert label_file.otherData["image_scale"]["value"] == 0.02
+        assert label_file.otherData["image_scale"]["unit"] == "mm"
+
+
+def test_export_preserves_pith_xy():
+    """Test that pith_xy is preserved in export when present."""
+    window = MockWindow()
+    window.pith_xy = (50, 75)
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = Path(tmpdir) / "test.json"
+        export_annotations_json(window, output_file)
+        
+        # Load and verify pith_xy is present
+        label_file = LabelFile(str(output_file))
+        assert "pith_xy" in label_file.otherData
+        assert label_file.otherData["pith_xy"] == (50, 75)
+
+
+def test_export_respects_store_data_config():
+    """Test that imageData inclusion respects store_data config."""
+    window = MockWindow()
+    window._config = {"store_data": False}
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = Path(tmpdir) / "test.json"
+        export_annotations_json(window, output_file)
+        
+        # Load and verify imageData is None
+        label_file = LabelFile(str(output_file), enforce_image_data=False)
+        assert label_file.imageData is None
+
+
+def test_export_empty_shapes_with_metadata():
+    """Test exporting empty shapes but with preprocessing and metadata."""
+    window = MockWindow()
+    window.otherData = {
+        "preprocessing": {
+            "crop_rect": (10, 20, 100, 150),
+            "scale_factor": 0.8,
+            "background_removed": False,
+            "original_size": [200, 100],
+            "processed_size": [160, 80],
+        }
+    }
+    window.sample_metadata = {
+        "harvested_year": 2023,
+        "sample_code": "TEST001",
+        "observation": "Test"
+    }
+    window.image_scale = {"value": 0.02, "unit": "mm"}
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = Path(tmpdir) / "test.json"
+        export_annotations_json(window, output_file)
+        
+        # Load and verify all metadata is present even with empty shapes
+        label_file = LabelFile(str(output_file))
+        assert label_file.shapes == []
+        assert "preprocessing" in label_file.otherData
+        assert "sample_metadata" in label_file.otherData
+        assert "image_scale" in label_file.otherData
+
+
+def test_export_with_flags():
+    """Test exporting with image-level flags."""
+    window = MockWindow()
+    
+    # Mock flag widget with flags
+    flag_item1 = MagicMock()
+    flag_item1.text.return_value = "verified"
+    flag_item1.checkState.return_value = 2  # Qt.Checked
+    
+    flag_item2 = MagicMock()
+    flag_item2.text.return_value = "reviewed"
+    flag_item2.checkState.return_value = 0  # Qt.Unchecked
+    
+    window.flag_widget.count.return_value = 2
+    window.flag_widget.item.side_effect = lambda i: [flag_item1, flag_item2][i]
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = Path(tmpdir) / "test.json"
+        export_annotations_json(window, output_file)
+        
+        # Load and verify flags
+        label_file = LabelFile(str(output_file))
+        assert label_file.flags["verified"] is True
+        assert label_file.flags["reviewed"] is False
+
+
+def test_export_creates_output_directory():
+    """Test that export creates output directory if it doesn't exist."""
+    window = MockWindow()
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = Path(tmpdir) / "subdir" / "test.json"
+        export_annotations_json(window, output_file)
+        
+        # Verify directory and file were created
+        assert output_file.parent.exists()
+        assert output_file.exists()
+

--- a/tras/utils/__init__.py
+++ b/tras/utils/__init__.py
@@ -1,4 +1,5 @@
 from ._io import lblsave
+from .annotation_export import export_annotations_json
 from .image import apply_exif_orientation
 from .image import img_arr_to_b64
 from .image import img_arr_to_data

--- a/tras/utils/annotation_export.py
+++ b/tras/utils/annotation_export.py
@@ -1,0 +1,185 @@
+"""Shared module for exporting annotations to JSON format.
+
+This module provides a single canonical implementation for exporting
+annotations that is used by both File > Save and Tools > Export Data.
+"""
+
+from __future__ import annotations
+
+import os.path as osp
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from loguru import logger
+
+from tras._label_file import LabelFile, LabelFileError
+
+if TYPE_CHECKING:
+    from PyQt5.QtCore import Qt
+    from PyQt5.QtWidgets import QListWidget, QListWidgetItem
+
+
+def _convert_numpy_types(obj: Any) -> Any:
+    """Recursively convert numpy types to native Python types for JSON serialization.
+    
+    Args:
+        obj: Object that may contain numpy types
+        
+    Returns:
+        Object with numpy types converted to native Python types
+    """
+    if isinstance(obj, np.integer):
+        return int(obj)
+    elif isinstance(obj, np.floating):
+        return float(obj)
+    elif isinstance(obj, np.ndarray):
+        return obj.tolist()
+    elif isinstance(obj, dict):
+        return {key: _convert_numpy_types(value) for key, value in obj.items()}
+    elif isinstance(obj, tuple):
+        return tuple(_convert_numpy_types(item) for item in obj)
+    elif isinstance(obj, list):
+        return [_convert_numpy_types(item) for item in obj]
+    else:
+        return obj
+
+
+def export_annotations_json(window, output_file: Path | str) -> None:
+    """Export annotations to JSON file using canonical format.
+    
+    This function implements the standard annotation export format used
+    by TRAS. It extracts shapes, flags, metadata, and preprocessing info
+    from the window and saves them to a JSON file.
+    
+    Args:
+        window: MainWindow instance with annotations, metadata, etc.
+        output_file: Path to output JSON file (will be created if needed)
+        
+    Raises:
+        LabelFileError: If export fails (e.g., invalid image path)
+        OSError: If output directory cannot be created
+        
+    Note:
+        - Exports even if there are zero shapes (empty shapes list)
+        - Includes preprocessing info if present in otherData
+        - Includes sample_metadata, image_scale, and pith_xy if available
+        - Respects window._config["store_data"] for imageData inclusion
+    """
+    output_file = Path(output_file)
+    
+    # Ensure output directory exists
+    if output_file.parent and not output_file.parent.exists():
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+    
+    lf = LabelFile()
+    
+    def format_shape(s):
+        """Format a shape for JSON export."""
+        data = s.other_data.copy() if hasattr(s, 'other_data') and s.other_data else {}
+        data.update(
+            dict(
+                label=s.label,
+                points=[(float(p.x()), float(p.y())) for p in s.points],
+                group_id=s.group_id if hasattr(s, 'group_id') else None,
+                description=s.description if hasattr(s, 'description') else "",
+                shape_type=s.shape_type,
+                flags=s.flags if hasattr(s, 'flags') else {},
+                mask=None
+                if not hasattr(s, 'mask') or s.mask is None
+                else _img_arr_to_b64(s.mask.astype(np.uint8)),
+            )
+        )
+        # Convert numpy types in shape data
+        return _convert_numpy_types(data)
+    
+    # Extract shapes from labelList
+    shapes = []
+    if hasattr(window, 'labelList') and window.labelList:
+        shapes = [format_shape(item.shape()) for item in window.labelList]
+    
+    # Extract flags from flag_widget
+    flags = {}
+    if hasattr(window, 'flag_widget') and window.flag_widget:
+        from PyQt5.QtCore import Qt
+        for i in range(window.flag_widget.count()):
+            item = window.flag_widget.item(i)
+            if item:
+                key = item.text()
+                flag = item.checkState() == Qt.Checked
+                flags[key] = flag
+    
+    # Prepare image path (relative to JSON file)
+    if not hasattr(window, 'imagePath') or not window.imagePath:
+        raise LabelFileError("Cannot export: imagePath is not set")
+    
+    try:
+        imagePath = osp.relpath(window.imagePath, osp.dirname(str(output_file)))
+    except ValueError:
+        # relpath can fail if paths are on different drives (Windows)
+        # Fall back to basename
+        logger.warning(f"Could not make imagePath relative, using basename")
+        imagePath = osp.basename(window.imagePath)
+    
+    # Include imageData based on config
+    imageData = None
+    if hasattr(window, '_config') and window._config.get("store_data", True):
+        imageData = getattr(window, 'imageData', None)
+    elif not hasattr(window, '_config'):
+        # If config doesn't exist, default to storing data
+        imageData = getattr(window, 'imageData', None)
+    
+    # Prepare otherData - start with existing otherData or empty dict
+    otherData = {}
+    if hasattr(window, 'otherData') and window.otherData:
+        otherData = window.otherData.copy()
+    
+    # Augment otherData with current state (only if present)
+    # Note: pith_xy and radial measurements should be cleared on preprocess,
+    # but we include them here if they exist
+    
+    if hasattr(window, 'pith_xy') and window.pith_xy is not None:
+        otherData["pith_xy"] = window.pith_xy
+    
+    if hasattr(window, 'sample_metadata') and window.sample_metadata is not None:
+        otherData["sample_metadata"] = window.sample_metadata
+    
+    if hasattr(window, 'image_scale') and window.image_scale is not None:
+        otherData["image_scale"] = window.image_scale
+    
+    # Preprocessing info is already in otherData if it was set, so we don't need to add it again
+    
+    # Convert numpy types to native Python types for JSON serialization
+    # This is critical for preprocessing info which may contain numpy int64 values
+    otherData = _convert_numpy_types(otherData)
+    
+    # Get image dimensions
+    if hasattr(window, 'image') and window.image:
+        imageHeight = window.image.height()
+        imageWidth = window.image.width()
+    else:
+        raise LabelFileError("Cannot export: image is not available")
+    
+    # Save to file
+    lf.save(
+        filename=str(output_file),
+        shapes=shapes,
+        imagePath=imagePath,
+        imageData=imageData,
+        imageHeight=imageHeight,
+        imageWidth=imageWidth,
+        otherData=otherData,
+        flags=flags,
+    )
+    
+    logger.info(f"Exported annotations to {output_file} ({len(shapes)} shapes)")
+
+
+def _img_arr_to_b64(img_arr: np.ndarray) -> str:
+    """Convert numpy image array to base64-encoded PNG string.
+    
+    This is a helper function that wraps the utils function.
+    """
+    from tras import utils
+    return utils.img_arr_to_b64(img_arr)
+


### PR DESCRIPTION
- Introduced a new test suite for annotation export utilities, covering various scenarios including empty shapes, shapes with metadata, and flags.
- Refactored the export logic to use a shared function for exporting annotations to JSON, ensuring consistency across different export methods.
- Enhanced error handling during the export process to provide user-friendly messages for potential issues.
- Updated the export dialog to utilize the new shared exporter, simplifying the code and improving maintainability.