### PR TITLE
Fix NameError in update dialog upgrade progress

### DIFF
--- a/tras/widgets/update_dialog.py
+++ b/tras/widgets/update_dialog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from loguru import logger
 from PyQt5 import QtCore, QtWidgets
 from PyQt5.QtWidgets import QApplication  # type: ignore
 


### PR DESCRIPTION
UpdateCheckDialog._on_upgrade_progress called logger.info() but the module never imported logger, crashing the upgrade flow with NameError. Add the missing loguru import, matching the convention used across the other widgets.