### PR TITLE
Add GUI batch processing + refactor docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,10 +45,18 @@ Image → Preprocessing (crop/resize/bg removal)
 | `tras/api.py` | `detect()` function and `DetectionResult` dataclass — programmatic pipeline entry point |
 | `tras/cli/detect.py` | `tras_detect` CLI (single image or batch folder via YAML config) |
 | `tras/tree_ring_methods/` | Detection algorithm implementations (see below) |
-| `tras/utils/` | Shared helpers: preprocessing, ring sampling, export, report generation |
-| `tras/widgets/` | Individual PyQt5 dialog widgets (canvas, export, preprocessing, scale, metadata) |
+| `tras/utils/` | Shared helpers: preprocessing, ring sampling, export, report generation, batch runner (`batch_helper.py`) |
+| `tras/widgets/` | Individual PyQt5 dialog widgets (canvas, export, preprocessing, scale, metadata, batch) |
 | `tras/_label_file.py` | JSON annotation file format with base64-embedded image and shape/flag metadata |
 | `tras/config/default_config.yaml` | Default UI settings and wood-themed color palette |
+| `tras/config/detection_defaults.yaml` | Single source of truth for detection defaults (method, pith, sampling, per-method params) |
+
+### Detection defaults (single source of truth)
+
+`tras/config/detection_defaults.yaml` holds the default detection parameters. Load it via
+`tras/config/detection_defaults.py::get_detection_defaults()` (cached). The GUI (`tree_ring_dialog.py`,
+`batch_dialog.py`), the API (`api.py`), and the CLI config layer (`cli_config.py`) all read from it —
+when adding or changing a detection parameter, update this YAML so every entry point stays in sync.
 
 ### Detection methods (`tras/tree_ring_methods/`)
 
@@ -64,9 +72,12 @@ Each method has a corresponding helper in `tras/utils/` (`apd_helper.py`, `cstrd
 
 Label files are JSON, written/read by `tras/_label_file.py`. Shapes use `labelme`-compatible format: rings are polygons, the pith is a point. Preprocessing metadata (scale factor, background mask) is stored in `flags`.
 
-### CLI batch processing
+### Batch processing
 
-`tras_detect` accepts a YAML config file for batch jobs. See `examples/cli/process_config.yml` for the full template covering scale, preprocessing, postprocessing, pith/ring method selection, and method-specific parameters.
+The Tools menu is split into **Single** (the open-image workflow) and **Batch Processing…**.
+
+- **CLI**: `tras_detect` accepts a YAML config file for batch jobs. See `examples/cli/process_config.yml` for the full template covering scale, preprocessing, postprocessing, pith/ring method selection, and method-specific parameters.
+- **GUI**: `tras/widgets/batch_dialog.py` (`BatchProcessDialog`) configures settings inline and runs `tras/utils/batch_helper.py::run_batch` in a worker thread. It iterates every image in the selected folder and **writes outputs into that same input folder**: one `.json` label file per image, a combined `summary.pdf` (one image per page, ring overlay, filename as title), and a CLI-compatible `batch_config.yml` of the settings used. Images that already have a `.json` are skipped, so a batch can be resumed. `batch_helper.py` is Qt-free and reuses `api.detect()`, `cli_config.get_detection_params()`, and `report_pdf.generate_summary_pdf()`.
 
 ## Testing conventions
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 <div align="center">
 
-# 🌲 TRAS - Tree Ring Analyzer Suite
-
-**Accepted as Software Article at Forestry: An International Journal of Forest Research** 
-
+# 🌲 TRAS — Tree Ring Analyzer Suite
 
 <p align="center">
   <img src="assets/tras-logo.png" alt="TRAS Logo" width="200"/>
@@ -11,11 +8,15 @@
 
 **Professional dendrochronology software for automatic tree ring detection and measurement**
 
+*Accepted as a Software Article at Forestry: An International Journal of Forest Research*
+
 [![Release](https://img.shields.io/github/v/release/hmarichal93/tras?color=green&label=Release)](https://github.com/hmarichal93/tras/releases/latest)
 [![Downloads](https://img.shields.io/github/downloads/hmarichal93/tras/total?color=blue&label=Downloads)](https://github.com/hmarichal93/tras/releases)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Python](https://img.shields.io/badge/Python-3.9%2B-blue)](https://www.python.org)
 [![arXiv](https://img.shields.io/badge/arXiv-2605.08025-b31b1b.svg)](https://arxiv.org/abs/2605.08025)
+
+[Overview](#-overview) • [Features](#-key-features) • [Installation](#-installation) • [Quick Start](#-quick-start) • [Workflow](#-workflow) • [Citations](#-citations)
 
 </div>
 
@@ -23,62 +24,21 @@
 
 ## 🎯 Overview
 
-TRAS integrates **state-of-the-art computer vision** and **deep learning methods** for dendrochronology research. Automatically detect tree rings, measure ring widths, and export data in standard formats—all through an intuitive graphical interface.
+TRAS integrates **state-of-the-art computer vision** and **deep learning** methods for dendrochronology research. Automatically detect tree rings, measure ring widths, and export data in standard formats — all through an intuitive graphical interface, a programmatic Python API, or a command-line tool for batch jobs.
 
 <p align="center">
   <img src="assets/screenshot-main.png" alt="TRAS Main Interface" width="800"/>
 </p>
 
-## Installation
-### 1. Python
-#### Conda
-##### 1. Download Anaconda
-> **Windows users**: [Video tutorial for installing Anaconda on Windows](https://youtu.be/4DQGBQMvwZo)
+**Three ways to use TRAS:**
 
-##### 2. Download TRAS
+| Interface | Command | Best for |
+|-----------|---------|----------|
+| 🖥️ **GUI** | `tras` | Interactive annotation, single samples, batch folders |
+| ⌨️ **CLI** | `tras_detect` | Scripting, reproducible batch pipelines |
+| 🐍 **Python API** | `from tras.api import detect` | Custom workflows and integration |
 
-**Linux/macOS:**
-```bash
-export TRAS_VERSION=2.0.2  # Change this value when updating to a newer release
-wget https://github.com/hmarichal93/tras/archive/refs/tags/v${TRAS_VERSION}.tar.gz
-tar -xzf v${TRAS_VERSION}.tar.gz
-cd tras-${TRAS_VERSION}
-```
-
-> **Alternative**: Download manually from [Releases](https://github.com/hmarichal93/tras/releases/latest) and extract
-
-> **🪟 Important for Windows Users:**
-> After downloading and extracting TRAS:
-> 1. Open **Anaconda Prompt** (not regular Command Prompt - search for "Anaconda Prompt" in the Start menu)
-> 2. Navigate to the extracted directory: `cd path\to\tras-$version`
-> 3. Then follow the installation commands below
-
-##### 3. Install
-```bash
-conda env create -f environment.yml
-conda activate tras
-pip install -e . 
-python tools/download_release_assets.py 
-```
-> **Note**: The download script automatically fetches all required model weights, including APD YOLO weights (`downloaded_assets/apd/yolo/all_best_yolov8.pt`) for the `apd_dl` method.
-
-### 2. Compile Devernay Edge Detector (for CS-TRD, Linux/macOS only)
-```bash
-# From the tras-${TRAS_VERSION} directory
-cd tras/tree_ring_methods/cstrd/devernay
-make
-cd ../../../..  # Return to tras-${TRAS_VERSION} directory
-```
-> **Note**: CS-TRD is not available on Windows. Windows users should use DeepCS-TRD instead.
-
-### 3. Install INBD Tree-Ring Detection Method (Optional)
-```bash
-mkdir -p tras/tree_ring_methods/inbd && cd tras/tree_ring_methods/inbd
-git clone https://github.com/hmarichal93/INBD.git src
-./download_models.sh
-```
-
-
+---
 
 ## ✨ Key Features
 
@@ -86,20 +46,20 @@ git clone https://github.com/hmarichal93/INBD.git src
 <tr>
 <td width="50%" valign="top">
 
-### 🔬 **Automatic Detection**
-- **APD**: Automatic Pith Detection (~1s, CPU) - includes `apd`, `apd_pcl`, and `apd_dl` (YOLO) methods
-- **CS-TRD**: Classical edge detection (~73s, CPU) *[Linux/macOS only]*
-- **DeepCS-TRD**: Deep learning U-Net (~101s, GPU)
-- **INBD**: Iterative Next Boundary Detection (CVPR 2023, GPU)
+### 🔬 Automatic Detection
+- **APD** — Automatic Pith Detection (~1 s, CPU); methods `apd`, `apd_pcl`, `apd_dl` (YOLO)
+- **CS-TRD** — Classical edge detection (~73 s, CPU) *[Linux/macOS only]*
+- **DeepCS-TRD** — Deep learning U-Net (~101 s, GPU)
+- **INBD** — Iterative Next Boundary Detection (CVPR 2023, GPU)
 
 <img src="assets/detection-methods.png" alt="Detection Methods" width="100%"/>
 
 </td>
 <td width="50%" valign="top">
 
-### 🖼️ **Preprocessing**
+### 🖼️ Preprocessing
 - Smart crop with edge warnings
-- Resize (10-100% scaling)
+- Resize (10–100 % scaling)
 - U2Net background removal
 - Full parameter tracking
 
@@ -110,22 +70,22 @@ git clone https://github.com/hmarichal93/INBD.git src
 <tr>
 <td width="50%" valign="top">
 
-### 📏 **Scale Calibration**
-- Draw known-length segment
+### 📏 Scale Calibration
+- Draw a known-length segment
 - Direct μm/cm/mm input
 - Auto-adjust on resize
-- Physical unit exports
+- Physical-unit exports
 
 <img src="assets/scale-calibration.png" alt="Scale Calibration" width="100%"/>
 
 </td>
 <td width="50%" valign="top">
 
-### 📊 **Analysis & Export**
+### 📊 Analysis & Export
 - Ring properties (area, perimeter)
 - Radial width measurements
 - Year-based labeling
-- CSV & .POS formats
+- JSON, CSV & .POS formats
 
 <img src="assets/analysis-export.png" alt="Analysis" width="100%"/>
 
@@ -133,9 +93,10 @@ git clone https://github.com/hmarichal93/INBD.git src
 </tr>
 </table>
 
-### 📄 **Professional PDF Reports**
+### 📄 Professional PDF Reports
 
-Generate comprehensive reports with a single click, including:
+Generate comprehensive reports with a single click:
+
 - Sample metadata and summary statistics
 - Ring overlay with detected boundaries
 - Multi-panel analysis plots (area, growth rate, radial width)
@@ -160,21 +121,100 @@ Generate comprehensive reports with a single click, including:
 </table>
 </p>
 
+---
+
+## 📦 Installation
+
+> **Windows users:** run every command below from the **Anaconda Prompt** (search "Anaconda Prompt" in the Start menu), **not** the regular Command Prompt. CS-TRD is unavailable on Windows — use DeepCS-TRD instead.
+
+### Prerequisites
+
+- [Anaconda / Miniconda](https://www.anaconda.com/download) — [Windows video tutorial](https://youtu.be/4DQGBQMvwZo)
+- Python ≥ 3.9 (provided by the conda environment)
+
+### 1. Download TRAS
+
+**Linux / macOS:**
+```bash
+export TRAS_VERSION=2.1.9          # update when a newer release is available
+wget https://github.com/hmarichal93/tras/archive/refs/tags/v${TRAS_VERSION}.tar.gz
+tar -xzf v${TRAS_VERSION}.tar.gz
+cd tras-${TRAS_VERSION}
+```
+
+> **Alternative:** download manually from [Releases](https://github.com/hmarichal93/tras/releases/latest) and extract, then `cd` into the extracted folder.
+
+### 2. Create the Environment
+
+```bash
+conda env create -f environment.yml
+conda activate tras
+pip install -e .
+```
+
+### 3. Download Model Weights
+
+```bash
+python tools/download_release_assets.py
+```
+
+> Fetches all required model weights, including the APD YOLO weights (`downloaded_assets/apd/yolo/all_best_yolov8.pt`) used by the `apd_dl` method.
+
+### 4. Compile the Devernay Edge Detector *(CS-TRD — Linux/macOS only, optional)*
+
+```bash
+cd tras/tree_ring_methods/cstrd/devernay
+make
+cd ../../../..                      # back to the project root
+```
+
+### 5. Install the INBD Method *(optional)*
+
+```bash
+mkdir -p tras/tree_ring_methods/inbd && cd tras/tree_ring_methods/inbd
+git clone https://github.com/hmarichal93/INBD.git src
+./download_models.sh
+cd ../../..                         # back to the project root
+```
+
+---
 
 ## 🚀 Quick Start
 
-### GUI Mode
+### 🖥️ GUI
+
 ```bash
-tras                              # Launch GUI
-tras /path/to/image.jpg          # Open with image
-tras --version                    # Check version
+tras                               # launch the GUI
+tras /path/to/image.jpg            # launch with an image open
+tras --version                     # print the version
 ```
 
-### CLI Mode
+The **Tools** menu has two groups:
 
-TRAS provides a unified command-line tool that automatically detects whether the input is a single image or a folder:
+- **Single** — the step-by-step workflow for the currently open image (set scale → preprocess → detect → measure → export).
+- **Batch Processing…** — run detection over an entire folder (see below).
 
-**Single Image Mode:**
+### 📁 GUI Batch Processing
+
+**`Tools → Batch Processing…`** opens a dialog where you pick an input folder and configure the
+detection settings inline — optional physical scale, preprocessing, pith method, and ring method
+with its parameters. Detection runs in the background with a live progress bar.
+
+For every image, TRAS writes a `.json` label file. When the batch finishes it also produces:
+
+| Output | Description |
+|--------|-------------|
+| `summary.pdf` | One page per image — detected rings overlaid on the image, with the filename as the page title |
+| `batch_config.yml` | The exact settings used, re-loadable by the CLI (`tras_detect --config`) |
+
+> 💡 All outputs are written **into the input folder itself**, alongside the images. Images that
+> already have a `.json` are skipped, so an interrupted batch resumes simply by running it again.
+
+### ⌨️ CLI
+
+`tras_detect` automatically detects whether the input is a single image or a folder.
+
+**Single image:**
 ```bash
 # Auto-detect pith and rings
 tras_detect image.jpg -o output.json
@@ -183,76 +223,95 @@ tras_detect image.jpg -o output.json
 tras_detect image.jpg --ring-method deepcstrd --pith-method apd_dl
 ```
 
-**Batch Folder Processing Mode:**
+**Batch folder:**
 ```bash
-# With YAML config file (recommended)
+# With a YAML config file (recommended)
 tras_detect /path/to/images --config config.yml
 
 # With CLI flags only
 tras_detect /path/to/images --scale-value 0.0213 --scale-unit mm --ring-method deepcstrd
 
-# Override config with CLI flags
+# Config file overridden by CLI flags
 tras_detect /path/to/images --config config.yml --scale-value 0.025 --ring-method cstrd
 ```
 
 **Outputs:**
-- **Single image**: Generates `<stem>_detected.json` (or custom output path)
-- **Batch processing**: For each image generates `<stem>.json`, `<stem>.csv`, and `<stem>.pdf`
+- **Single image** → `<stem>_detected.json` (or your custom `-o` path)
+- **Batch folder** → `tras_out/<stem>.json`, `<stem>.csv`, and `<stem>.pdf` per image
 
-**Configuration File:**
-See [`examples/cli/process_config.yml`](examples/cli/process_config.yml) for a complete YAML configuration template.
+> **Required for CLI batch processing:** a physical scale must be provided, either via the config
+> file or via `--scale-value` and `--scale-unit`.
 
-**Required for batch processing:** Physical scale (`--scale-value` and `--scale-unit`) must be provided either via config file or CLI flags.
+See [`examples/cli/process_config.yml`](examples/cli/process_config.yml) for a complete configuration template.
 
-## 🧠 Training Custom Models
-
-TRAS supports loading user-trained models for INBD and DeepCS-TRD to improve detection on your specific datasets.
-See the **[Training Custom Models guide](docs/training_custom_models.md)** for step-by-step instructions.
+---
 
 ## 📖 Workflow
 
-
 <details>
-<summary><b>📋 Step-by-step guide</b></summary>
+<summary><b>📋 Step-by-step guide (single image)</b></summary>
 
-1. **📁 Load Image**
-   - `File > Open` or drag-and-drop wood cross-section image
+<br/>
 
-2. **📏 Set Scale** *(optional)*
-   - `Tools > Set Image Scale`
-   - Draw known-length line or enter directly
+> These per-image tools live under the **`Tools → Single`** submenu. To process a whole folder at
+> once, use **`Tools → Batch Processing…`** instead (see [GUI Batch Processing](#-gui-batch-processing)).
 
-3. **🖼️ Preprocess** *(optional)*
-   - `Tools > Preprocess Image`
-   - Crop, resize, or remove background
-
-4. **🎯 Detect Rings**
-   - `Tools > Tree Ring Detection`
-   - Choose pith: APD (auto, with methods: `apd`, `apd_pcl`, or `apd_dl`) or manual click
-   - Select method: CS-TRD (Linux/macOS), DeepCS-TRD, or INBD (all platforms)
-
-5. **📝 Add Metadata**
-   - `Tools > Sample Metadata`
-   - Harvested year, sample code, notes
-
-6. **📐 Measure Width** *(optional)*
-   - `Tools > Measure Ring Width`
-   - Define radial transect
-
-7. **📊 View Properties**
-   - `Tools > Ring Properties`
-   - Review measurements
-
-8. **💾 Export**
-   - CSV (all data) or .POS (CooRecorder format)
+1. **📁 Load Image** — `File → Open` or drag-and-drop a wood cross-section image
+2. **📏 Set Scale** *(optional)* — `Tools → Single → Set Image Scale`; draw a known-length line or enter it directly
+3. **🖼️ Preprocess** *(optional)* — `Tools → Single → Preprocess Image`; crop, resize, or remove background
+4. **🎯 Detect Rings** — `Tools → Single → Tree Ring Detection`
+   - Pith: APD auto (`apd`, `apd_pcl`, `apd_dl`) or manual click
+   - Method: CS-TRD (Linux/macOS), DeepCS-TRD, or INBD
+5. **📝 Add Metadata** — `Tools → Single → Sample Metadata`; harvested year, sample code, notes
+6. **📐 Measure Width** *(optional)* — `Tools → Single → Measure Ring Width`; define a radial transect
+7. **📊 View Properties** — `Tools → Single → Ring Properties`; review measurements
+8. **💾 Export** — JSON, CSV (all data), or .POS (CooRecorder format)
 
 </details>
 
-## Citations
+---
 
-If you use TRAS in your research, please cite the following papers:
+## 🧠 Training Custom Models
 
-### UruDendro
+TRAS supports loading user-trained models for **INBD** and **DeepCS-TRD** to improve detection on
+your specific datasets. See the **[Training Custom Models guide](docs/training_custom_models.md)**
+for step-by-step instructions.
+
+---
+
+## ⚙️ Configuration
+
+TRAS stores its configuration in `~/.trasrc`. You can customize:
+
+- Default shape colors (wood theme)
+- Keyboard shortcuts
+- Detection method defaults
+- UI preferences
+
+---
+
+## 📋 Requirements
+
+- Python ≥ 3.9
+- PyQt5
+- OpenCV
+- PyTorch (for DeepCS-TRD)
+- Shapely 1.7.0
+
+See [`pyproject.toml`](pyproject.toml) for the complete dependency list.
+
+---
+
+## 📚 Citations
+
+If you use TRAS in your research, please cite the relevant papers below.
+
+<details>
+<summary><b>📖 BibTeX entries</b></summary>
+
+<br/>
+
+**UruDendro**
 ```bibtex
 @article{UruDendro,
   author    = {Henry Marichal and Diego Passarella and Christine Lucas and Ludmila Profumo and Verónica Casaravilla and María Noel Rocha Galli and Serrana Ambite and Gregory Randall},
@@ -268,7 +327,7 @@ If you use TRAS in your research, please cite the following papers:
 }
 ```
 
-### APD (Automatic Pith Detection)
+**APD — Automatic Pith Detection**
 ```bibtex
 @inproceedings{apd,
   isbn = {978-3-031-78447-7},
@@ -280,7 +339,7 @@ If you use TRAS in your research, please cite the following papers:
 }
 ```
 
-### CS-TRD (Cross-Section Tree Ring Detection)
+**CS-TRD — Cross-Section Tree Ring Detection**
 ```bibtex
 @article{ipol.2025.485,
     title   = {{CS-TRD: a Cross-Section Tree Ring Detection Method}},
@@ -293,7 +352,7 @@ If you use TRAS in your research, please cite the following papers:
 }
 ```
 
-### DeepCS-TRD (Deep Learning Tree Ring Detection)
+**DeepCS-TRD — Deep Learning Tree Ring Detection**
 ```bibtex
 @InProceedings{10.1007/978-3-032-10185-3_3,
 author="Marichal, Henry
@@ -308,7 +367,7 @@ and Randall, Gregory",
 editor="Rodol{\`a}, Emanuele
 and Galasso, Fabio
 and Masi, Iacopo",
-title="DeepCS-TRD, a Deep Learning-Based Cross-Section Tree Ring Detector",
+title="DeepCS-TRD, a Deep Learning-Based Cross-Section Tree Ring Detector",
 booktitle="Image Analysis and Processing -- ICIAP 2025",
 year="2026",
 publisher="Springer Nature Switzerland",
@@ -318,36 +377,24 @@ isbn="978-3-032-10185-3"
 }
 ```
 
-## Requirements
+</details>
 
-- Python ≥ 3.9
-- PyQt5
-- OpenCV
-- PyTorch (for DeepCS-TRD)
-- Shapely 1.7.0
-- See `pyproject.toml` for complete list
-
-## Configuration
-
-TRAS stores its configuration in `~/.trasrc`. You can customize:
-- Default shape colors (wood theme)
-- Keyboard shortcuts
-- Detection method defaults
-- UI preferences
-
-## License
-
-GPL-3.0-only
+---
 
 ## 🤝 Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
+Contributions are welcome! Feel free to submit a Pull Request. For major changes, please open an
+issue first to discuss what you would like to change.
+
+## 📄 License
+
+[GPL-3.0-only](LICENSE)
 
 ## 📧 Contact
 
-- **Author**: Henry Marichal ([@hmarichal93](https://github.com/hmarichal93))
-- **Email**: hmarichal93@gmail.com
-- **Website**: [https://hmarichal93.github.io/tras/](https://hmarichal93.github.io/tras/)
+- **Author:** Henry Marichal ([@hmarichal93](https://github.com/hmarichal93))
+- **Email:** hmarichal93@gmail.com
+- **Website:** [https://hmarichal93.github.io/tras/](https://hmarichal93.github.io/tras/)
 
 ## 🙏 Acknowledgments
 
@@ -358,7 +405,7 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
 
 <div align="center">
 
-**TRAS v2.0.2** - Tree Ring Analyzer Suite
+**TRAS** — Tree Ring Analyzer Suite
 
 *Advancing dendrochronology research through intelligent automation*
 

--- a/tests/utils_tests/test_batch_helper.py
+++ b/tests/utils_tests/test_batch_helper.py
@@ -1,0 +1,112 @@
+"""Tests for the Qt-free batch processing runner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from tras.api import DetectionResult
+from tras.api import _save_detection_results
+from tras.utils import batch_helper
+
+
+def _write_png(path: Path) -> None:
+    Image.fromarray(np.zeros((16, 16, 3), dtype=np.uint8)).save(path)
+
+
+def _fake_result(output: Path | None) -> DetectionResult:
+    image = np.zeros((16, 16, 3), dtype=np.uint8)
+    rings = [np.array([[2, 2], [12, 2], [12, 12], [2, 12]], dtype=np.float32)]
+    pith = (8.0, 8.0)
+    if output is not None:
+        _save_detection_results(Path(output), image, pith, rings)
+    return DetectionResult(
+        image=image, pith_xy=pith, rings=rings, preprocessing=None, output_path=output
+    )
+
+
+@pytest.fixture
+def input_dir(tmp_path: Path) -> Path:
+    folder = tmp_path / "imgs"
+    folder.mkdir()
+    for name in ("a.png", "b.png", "c.png"):
+        _write_png(folder / name)
+    return folder
+
+
+CONFIG = {"rings": {"method": "deepcstrd"}}
+
+
+def test_run_batch_writes_outputs(input_dir: Path, tmp_path: Path, monkeypatch):
+    calls: list[str] = []
+
+    def fake_detect(image_path, output=None, **kwargs):
+        calls.append(Path(image_path).name)
+        return _fake_result(output)
+
+    monkeypatch.setattr(batch_helper, "detect", fake_detect)
+    out = tmp_path / "out"
+
+    summary = batch_helper.run_batch(input_dir, out, CONFIG)
+
+    assert sorted(calls) == ["a.png", "b.png", "c.png"]
+    for name in ("a", "b", "c"):
+        assert (out / f"{name}.json").exists()
+    assert (out / "summary.pdf").exists()
+    assert (out / "batch_config.yml").exists()
+    assert summary.processed == 3
+    assert summary.skipped == 0
+    assert summary.errors == 0
+
+
+def test_run_batch_skips_existing_json(input_dir: Path, tmp_path: Path, monkeypatch):
+    out = tmp_path / "out"
+    out.mkdir()
+    # Pre-create b.json so it should be skipped (not re-detected) but still summarized.
+    _fake_result(out / "b.json")
+
+    calls: list[str] = []
+
+    def fake_detect(image_path, output=None, **kwargs):
+        calls.append(Path(image_path).name)
+        return _fake_result(output)
+
+    monkeypatch.setattr(batch_helper, "detect", fake_detect)
+
+    summary = batch_helper.run_batch(input_dir, out, CONFIG)
+
+    assert calls == ["a.png", "c.png"]  # b.png skipped
+    assert summary.processed == 2
+    assert summary.skipped == 1
+    assert summary.errors == 0
+    assert (out / "summary.pdf").exists()
+
+
+def test_run_batch_continues_after_error(input_dir: Path, tmp_path: Path, monkeypatch):
+    def fake_detect(image_path, output=None, **kwargs):
+        if Path(image_path).name == "b.png":
+            raise RuntimeError("boom")
+        return _fake_result(output)
+
+    monkeypatch.setattr(batch_helper, "detect", fake_detect)
+    out = tmp_path / "out"
+
+    summary = batch_helper.run_batch(input_dir, out, CONFIG)
+
+    assert summary.processed == 2
+    assert summary.errors == 1
+    assert summary.error_names == ["b.png"]
+    assert (out / "a.json").exists()
+    assert (out / "c.json").exists()
+    assert not (out / "b.json").exists()
+    assert (out / "summary.pdf").exists()
+
+
+def test_find_images_filters_and_sorts(tmp_path: Path):
+    for name in ("z.png", "a.JPG", "note.txt", "b.tiff"):
+        (tmp_path / name).write_bytes(b"x")
+    names = [p.name for p in batch_helper.find_images(tmp_path)]
+    assert names == ["a.JPG", "b.tiff", "z.png"]

--- a/tests/utils_tests/test_report_pdf.py
+++ b/tests/utils_tests/test_report_pdf.py
@@ -1,0 +1,33 @@
+"""Tests for the batch summary PDF generator."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import numpy as np
+
+from tras.utils.report_pdf import generate_summary_pdf
+
+
+def _fake_result(name: str) -> dict:
+    return {
+        "name": name,
+        "image": np.zeros((16, 16, 3), dtype=np.uint8),
+        "pith_xy": (8.0, 8.0),
+        "rings": [np.array([[2, 2], [12, 2], [12, 12], [2, 12]], dtype=np.float32)],
+    }
+
+
+def test_generate_summary_pdf_one_page_per_image(tmp_path: Path):
+    results = [_fake_result("a.png"), _fake_result("b.png")]
+    out = tmp_path / "summary.pdf"
+
+    generate_summary_pdf(out, results)
+
+    assert out.exists()
+    data = out.read_bytes()
+    assert data.startswith(b"%PDF")
+    # One "/Type /Page" object per page ("/Type /Pages" excluded via word boundary).
+    page_count = len(re.findall(rb"/Type\s*/Page\b", data))
+    assert page_count == 2

--- a/tras/app.py
+++ b/tras/app.py
@@ -47,6 +47,7 @@ from tras.widgets import RingPropertiesDialog
 from tras.widgets import MetadataDialog
 from tras.widgets import ShortcutsDialog
 from tras.widgets import UpdateCheckDialog
+from tras.widgets import BatchProcessDialog
 
 from . import utils
 from tras.utils.qt_image import qimage_to_numpy
@@ -815,7 +816,15 @@ class MainWindow(QtWidgets.QMainWindow):
             self.tr("Step 8: Export annotations, measurements, and PDF report"),
             enabled=False,
         )
-        
+
+        # Batch processing action (works on a folder, not the open image)
+        batchProcess = action(
+            self.tr("Batch Processing..."),
+            self._action_batch_process,
+            None,
+            "objects",
+            self.tr("Detect rings over every image in a folder"),
+        )
 
         # Group zoom controls into a list for easier toggling.
         self.zoom_actions = (
@@ -905,8 +914,9 @@ class MainWindow(QtWidgets.QMainWindow):
             ),
         )
         utils.addActions(self.menus.help, (help, keyboardShortcuts, None, checkUpdates, None, about))
-        # Tools menu organized by workflow order
-        utils.addActions(self.menus.tools, (
+        # Tools menu: "Single" submenu (open-image workflow) + "Batch" entry (folder).
+        self.menus.tools_single = QtWidgets.QMenu(self.tr("Single"))
+        utils.addActions(self.menus.tools_single, (
             metadata,           # Step 1: Sample Metadata (optional, before starting)
             None,
             setScale,           # Step 2: Set Scale
@@ -918,6 +928,11 @@ class MainWindow(QtWidgets.QMainWindow):
             measureRadialWidth, # Step 6: Measure Width
             ringProperties,     # Step 7: View Properties
             exportData,         # Step 8: Export Data
+        ))
+        utils.addActions(self.menus.tools, (
+            self.menus.tools_single,
+            None,
+            batchProcess,       # Batch: process a whole folder
         ))
         utils.addActions(
             self.menus.view,
@@ -2208,6 +2223,11 @@ class MainWindow(QtWidgets.QMainWindow):
         from tras.widgets import ExportDialog
         
         dlg = ExportDialog(parent=self)
+        dlg.exec_()
+
+    def _action_batch_process(self) -> None:
+        """Detect rings over every image in a folder (batch processing)."""
+        dlg = BatchProcessDialog(parent=self)
         dlg.exec_()
 
     def _rename_open_rings_with_years(self, pith_xy: tuple[float, float] | None) -> None:

--- a/tras/utils/batch_helper.py
+++ b/tras/utils/batch_helper.py
@@ -1,0 +1,178 @@
+"""Qt-free batch processing runner for the TRAS GUI.
+
+Mirrors the CLI ``_process_folder`` loop (``tras/cli/detect.py``) but tailored to the
+GUI batch feature: it writes one ``.json`` label file per image, then a single combined
+``summary.pdf`` (one image per page) and a CLI-compatible ``batch_config.yml`` recording
+the settings used. Already-processed images (those with an existing ``.json``) are
+skipped so a batch can be resumed.
+
+This module is intentionally free of any Qt dependency so it can be tested headless.
+The Qt threading wrapper lives in ``tras/widgets/batch_dialog.py``.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+from typing import Any
+from typing import Callable
+
+import numpy as np
+import numpy.typing as npt
+from loguru import logger
+from PIL import Image as PILImage
+
+from tras._label_file import LabelFile
+from tras.api import detect
+from tras.utils.cli_config import dump_config
+from tras.utils.cli_config import get_detection_params
+from tras.utils.report_pdf import generate_summary_pdf
+
+# Broader than the CLI's {.jpg, .jpeg, .png}: the GUI also opens TIFF/BMP images.
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".tif", ".tiff", ".bmp"}
+
+# progress(current_index, total, image_name)
+ProgressCallback = Callable[[int, int, str], None]
+
+
+@dataclass(frozen=True)
+class BatchSummary:
+    """Outcome of a batch run."""
+
+    total: int
+    processed: int
+    skipped: int
+    errors: int
+    output_dir: Path
+    summary_pdf: Path
+    config_path: Path
+    error_names: list[str] = field(default_factory=list)
+
+
+def find_images(input_dir: Path) -> list[Path]:
+    """Return image files in ``input_dir`` (non-recursive), sorted by name."""
+    return sorted(
+        f
+        for f in input_dir.iterdir()
+        if f.is_file() and f.suffix.lower() in IMAGE_EXTENSIONS
+    )
+
+
+def _scale_from_config(config: dict[str, Any]) -> tuple[float | None, str | None]:
+    """Extract optional (value, unit) physical scale from the config dict."""
+    scale = config.get("physical_scale")
+    if not isinstance(scale, dict):
+        return None, None
+    try:
+        return float(scale["value"]), str(scale["unit"])
+    except (KeyError, TypeError, ValueError):
+        return None, None
+
+
+def _decode_embedded_image(image_data: bytes) -> npt.NDArray[np.uint8]:
+    """Decode the base64-embedded image bytes stored in a label file into RGB array."""
+    pil_img = PILImage.open(io.BytesIO(image_data)).convert("RGB")
+    return np.array(pil_img, dtype=np.uint8)
+
+
+def _load_result_from_json(
+    json_path: Path,
+) -> tuple[npt.NDArray[np.uint8], tuple[float, float], list[npt.NDArray[np.float32]]]:
+    """Recover (image, pith_xy, rings) from an existing TRAS label file.
+
+    Used to include already-processed (skipped) images in the summary PDF.
+    """
+    label = LabelFile(str(json_path))
+    image = _decode_embedded_image(label.imageData)
+
+    pith_xy: tuple[float, float] = (0.0, 0.0)
+    rings: list[npt.NDArray[np.float32]] = []
+    for shape in label.shapes:
+        if shape["label"] == "pith" and shape["points"]:
+            point = shape["points"][0]
+            pith_xy = (float(point[0]), float(point[1]))
+        elif shape["shape_type"] == "polygon":
+            rings.append(np.array(shape["points"], dtype=np.float32))
+    return image, pith_xy, rings
+
+
+def run_batch(
+    input_dir: Path | str,
+    output_dir: Path | str,
+    config: dict[str, Any],
+    progress: ProgressCallback | None = None,
+) -> BatchSummary:
+    """Detect rings for every image in a folder and write batch outputs.
+
+    For each image: skip if its ``.json`` already exists (still included in the
+    summary), otherwise run detection and write its ``.json``. Per-image failures are
+    logged and counted but never abort the batch. After the loop, writes
+    ``summary.pdf`` and ``batch_config.yml`` into ``output_dir``.
+    """
+    input_dir = Path(input_dir)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    params = get_detection_params(config)
+    scale_value, scale_unit = _scale_from_config(config)
+
+    images = find_images(input_dir)
+    total = len(images)
+    logger.info(f"Batch: found {total} image(s) in {input_dir}")
+
+    results: list[dict[str, Any]] = []
+    processed = skipped = errors = 0
+    error_names: list[str] = []
+
+    for idx, image_path in enumerate(images, 1):
+        name = image_path.name
+        if progress is not None:
+            progress(idx, total, name)
+
+        json_path = output_dir / f"{image_path.stem}.json"
+        try:
+            if json_path.exists():
+                logger.info(f"[{idx}/{total}] Skipping {name} (JSON already exists)")
+                image, pith_xy, rings = _load_result_from_json(json_path)
+                skipped += 1
+            else:
+                logger.info(f"[{idx}/{total}] Processing {name}")
+                detection = detect(image_path=image_path, output=json_path, **params)
+                image, pith_xy, rings = (
+                    detection.image,
+                    detection.pith_xy,
+                    detection.rings,
+                )
+                processed += 1
+            results.append(
+                {"name": name, "image": image, "pith_xy": pith_xy, "rings": rings}
+            )
+        except Exception as exc:
+            logger.error(f"[{idx}/{total}] Failed to process {name}: {exc}")
+            errors += 1
+            error_names.append(name)
+
+    summary_pdf = output_dir / "summary.pdf"
+    if results:
+        generate_summary_pdf(summary_pdf, results, scale_value, scale_unit)
+    else:
+        logger.warning("Batch produced no results; skipping summary PDF")
+
+    config_path = output_dir / "batch_config.yml"
+    dump_config(config, config_path)
+
+    logger.info(
+        f"Batch complete: {processed} processed, {skipped} skipped, {errors} error(s)"
+    )
+    return BatchSummary(
+        total=total,
+        processed=processed,
+        skipped=skipped,
+        errors=errors,
+        output_dir=output_dir,
+        summary_pdf=summary_pdf,
+        config_path=config_path,
+        error_names=error_names,
+    )

--- a/tras/utils/cli_config.py
+++ b/tras/utils/cli_config.py
@@ -50,6 +50,22 @@ def load_config(config_path: Optional[Path]) -> dict[str, Any]:
         raise ConfigError(f"Failed to load config file: {e}") from e
 
 
+def dump_config(config: dict[str, Any], path: Path) -> None:
+    """Write a config dict to a YAML file in the schema ``load_config`` reads.
+
+    The output is CLI-compatible: it can be passed back to ``tras_detect`` via
+    ``--config``. ``sort_keys=False`` preserves the logical section order.
+
+    Args:
+        config: Configuration dictionary (same shape as ``process_config.yml``).
+        path: Destination YAML file path.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(config, f, sort_keys=False, default_flow_style=False)
+    logger.info(f"Wrote config to {path}")
+
+
 def validate_config(config: dict[str, Any]) -> None:
     """Validate that required configuration fields are present.
 

--- a/tras/utils/report_pdf.py
+++ b/tras/utils/report_pdf.py
@@ -70,6 +70,49 @@ def generate_pdf_report(
     logger.info(f"Generated PDF report: {output_path}")
 
 
+def generate_summary_pdf(
+    output_path: Path,
+    results: list[dict[str, Any]],
+    scale_value: Optional[float] = None,
+    scale_unit: Optional[str] = None,
+) -> None:
+    """Generate a combined batch summary PDF, one image per page.
+
+    Each page shows the image with its detected ring boundaries overlaid and the
+    image filename as the page title. Used by GUI batch processing.
+
+    Args:
+        output_path: Path to the output ``summary.pdf``.
+        results: One dict per processed image, each with keys ``name`` (str,
+            shown as the page title), ``image`` (H x W x 3 uint8 array),
+            ``pith_xy`` (x, y), and ``rings`` (list of ring polygons).
+        scale_value: Optional physical scale (unit per pixel); reserved for future
+            per-page statistics. Pixel units are used when omitted.
+        scale_unit: Optional physical unit name accompanying ``scale_value``.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with PdfPages(str(output_path)) as pdf:
+        for result in results:
+            _create_ring_overlay_page(
+                pdf,
+                result["image"],
+                result["rings"],
+                result["pith_xy"],
+                show_labels=True,
+                title=result["name"],
+            )
+
+        pdf_metadata = pdf.infodict()
+        pdf_metadata["Title"] = "Tree Ring Batch Summary"
+        pdf_metadata["Author"] = "TRAS - Tree Ring Analyzer Suite"
+        pdf_metadata["Subject"] = f"Batch of {len(results)} image(s)"
+        pdf_metadata["Keywords"] = "Dendrochronology, Tree Rings, Wood Analysis"
+        pdf_metadata["CreationDate"] = datetime.now()
+
+    logger.info(f"Generated batch summary PDF: {output_path} ({len(results)} pages)")
+
+
 def _create_cover_page(
     pdf: PdfPages,
     ring_properties: list[dict[str, Any]],
@@ -172,10 +215,21 @@ def _create_ring_overlay_page(
     rings: list[npt.NDArray[np.float32]],
     pith_xy: tuple[float, float],
     show_labels: bool = True,
+    title: Optional[str] = None,
 ) -> None:
-    """Create page with image and ring overlays."""
+    """Create page with image and ring overlays.
+
+    Args:
+        title: Optional page title. If omitted, a default title is used based on
+            ``show_labels`` (existing single-report behaviour).
+    """
     fig, ax = plt.subplots(figsize=(8.5, 11))
-    title = "Tree Rings with Detected Boundaries" if show_labels else "Tree Rings (Overlay)"
+    if title is None:
+        title = (
+            "Tree Rings with Detected Boundaries"
+            if show_labels
+            else "Tree Rings (Overlay)"
+        )
     ax.imshow(image)
     ax.set_title(title, fontsize=16, fontweight="bold", pad=20)
     img_height, img_width = image.shape[:2]

--- a/tras/widgets/__init__.py
+++ b/tras/widgets/__init__.py
@@ -17,3 +17,4 @@ from .unique_label_qlist_widget import UniqueLabelQListWidget
 from .update_dialog import UpdateCheckDialog
 from .zoom_widget import ZoomWidget
 from .export_dialog import ExportDialog
+from .batch_dialog import BatchProcessDialog

--- a/tras/widgets/batch_dialog.py
+++ b/tras/widgets/batch_dialog.py
@@ -1,0 +1,483 @@
+"""Batch processing dialog for the TRAS GUI.
+
+Lets the user pick an input folder, configure detection settings inline, and run ring
+detection over every image. Outputs one ``.json`` per image plus a combined
+``summary.pdf`` and a CLI-compatible ``batch_config.yml``. Detection runs in a worker
+thread so the GUI stays responsive.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+from PyQt5 import QtCore
+from PyQt5 import QtWidgets
+
+from tras.config.detection_defaults import get_detection_defaults
+from tras.utils.batch_helper import BatchSummary
+from tras.utils.batch_helper import find_images
+from tras.utils.batch_helper import run_batch
+
+# DeepCS-TRD predefined model ids (id, display label); mirrors TreeRingDialog.
+_DEEPCSTRD_MODELS = [
+    ("generic", "generic (all species)"),
+    ("pinus_v1", "pinus_v1 (Pinus taeda v1)"),
+    ("pinus_v2", "pinus_v2 (Pinus taeda v2)"),
+    ("gleditsia", "gleditsia (Gleditsia triacanthos)"),
+    ("salix", "salix (Salix glauca)"),
+]
+
+_INBD_MODELS = [
+    ("INBD_EH", "INBD_EH (Empetrum hermaphroditum)"),
+    ("INBD_DO", "INBD_DO (Dryas octopetala)"),
+    ("INBD_VM", "INBD_VM (Vaccinium myrtillus)"),
+    ("INBD_UruDendro1", "INBD_UruDendro1 (Pinus taeda)"),
+]
+
+_RING_METHODS = [
+    ("deepcstrd", "DeepCS-TRD (deep learning, GPU)"),
+    ("cstrd", "CS-TRD (classical, CPU)"),
+    ("inbd", "INBD (instance segmentation, GPU)"),
+]
+
+
+class BatchWorker(QtCore.QObject):
+    """Runs :func:`run_batch` in a worker thread, reporting progress via signals."""
+
+    progress = QtCore.pyqtSignal(int, int, str)  # current, total, name
+    finished = QtCore.pyqtSignal(object)  # BatchSummary
+    error = QtCore.pyqtSignal(str)
+
+    def __init__(self, input_dir: Path, output_dir: Path, config: dict[str, Any]):
+        super().__init__()
+        self._input_dir = input_dir
+        self._output_dir = output_dir
+        self._config = config
+
+    def run(self) -> None:
+        try:
+            summary = run_batch(
+                self._input_dir,
+                self._output_dir,
+                self._config,
+                progress=lambda i, n, name: self.progress.emit(i, n, name),
+            )
+            self.finished.emit(summary)
+        except Exception as exc:  # pragma: no cover - surfaced to the dialog
+            logger.exception("Batch processing failed")
+            self.error.emit(str(exc))
+
+
+class BatchProcessDialog(QtWidgets.QDialog):
+    """Configure and run folder-wide tree ring detection."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None):
+        super().__init__(parent)
+        self.setWindowTitle(self.tr("Batch Processing"))
+        self.setMinimumWidth(520)
+        self._defaults = get_detection_defaults()
+        self._settings = QtCore.QSettings("TRAS", "TRAS")
+        self._thread: QtCore.QThread | None = None
+        self._worker: BatchWorker | None = None
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(self._build_folders_group())
+        layout.addWidget(self._build_scale_group())
+        layout.addWidget(self._build_preprocess_group())
+        layout.addWidget(self._build_pith_group())
+        layout.addWidget(self._build_rings_group())
+        layout.addWidget(self._build_run_section())
+
+        self._load_settings()
+
+    # ----- UI construction -------------------------------------------------
+
+    def _build_folders_group(self) -> QtWidgets.QGroupBox:
+        group = QtWidgets.QGroupBox(self.tr("Folder"))
+        form = QtWidgets.QFormLayout(group)
+
+        self.input_edit = QtWidgets.QLineEdit()
+        in_browse = QtWidgets.QPushButton(self.tr("Browse..."))
+        in_browse.clicked.connect(self._pick_input_dir)
+        form.addRow(
+            self.tr("Input folder:"), self._with_button(self.input_edit, in_browse)
+        )
+        # Outputs (.json, summary.pdf, batch_config.yml) go into this same folder.
+        note = QtWidgets.QLabel(self.tr("Results are written into the input folder."))
+        note.setStyleSheet("color: gray;")
+        form.addRow("", note)
+        return group
+
+    def _build_scale_group(self) -> QtWidgets.QGroupBox:
+        group = QtWidgets.QGroupBox(self.tr("Physical scale (optional)"))
+        form = QtWidgets.QFormLayout(group)
+        self.scale_value = QtWidgets.QDoubleSpinBox()
+        self.scale_value.setDecimals(6)
+        self.scale_value.setRange(0.0, 1000.0)
+        self.scale_value.setSingleStep(0.001)
+        self.scale_value.setToolTip(
+            self.tr("Unit per pixel. Leave at 0 for pixel units.")
+        )
+        self.scale_unit = QtWidgets.QComboBox()
+        self.scale_unit.addItems(["mm", "cm", "um"])
+        form.addRow(self.tr("Value (unit/px):"), self.scale_value)
+        form.addRow(self.tr("Unit:"), self.scale_unit)
+        return group
+
+    def _build_preprocess_group(self) -> QtWidgets.QGroupBox:
+        group = QtWidgets.QGroupBox(self.tr("Preprocessing"))
+        form = QtWidgets.QFormLayout(group)
+        self.resize_scale = QtWidgets.QDoubleSpinBox()
+        self.resize_scale.setRange(0.1, 1.0)
+        self.resize_scale.setSingleStep(0.1)
+        self.resize_scale.setValue(1.0)
+        self.resize_scale.setToolTip(self.tr("Resize factor (1.0 = no resize)."))
+        self.remove_bg = QtWidgets.QCheckBox(self.tr("Remove background (U2Net)"))
+        form.addRow(self.tr("Resize scale:"), self.resize_scale)
+        form.addRow("", self.remove_bg)
+        return group
+
+    def _build_pith_group(self) -> QtWidgets.QGroupBox:
+        group = QtWidgets.QGroupBox(self.tr("Pith detection"))
+        form = QtWidgets.QFormLayout(group)
+        self.pith_auto = QtWidgets.QCheckBox(self.tr("Auto-detect pith (APD)"))
+        self.pith_auto.setChecked(self._defaults["pith"]["auto"])
+        self.pith_method = QtWidgets.QComboBox()
+        self.pith_method.addItems(["apd", "apd_pcl", "apd_dl"])
+        self._select_data(
+            self.pith_method, self._defaults["pith"]["method"], by_text=True
+        )
+        form.addRow("", self.pith_auto)
+        form.addRow(self.tr("APD method:"), self.pith_method)
+        return group
+
+    def _build_rings_group(self) -> QtWidgets.QGroupBox:
+        group = QtWidgets.QGroupBox(self.tr("Ring detection"))
+        outer = QtWidgets.QVBoxLayout(group)
+
+        top = QtWidgets.QFormLayout()
+        self.ring_method = QtWidgets.QComboBox()
+        for method_id, label in _RING_METHODS:
+            self.ring_method.addItem(label, method_id)
+        self._select_data(self.ring_method, self._defaults["method"])
+        self.ring_method.currentIndexChanged.connect(self._on_method_changed)
+
+        self.sampling_nr = QtWidgets.QSpinBox()
+        self.sampling_nr.setRange(36, 720)
+        self.sampling_nr.setValue(self._defaults["sampling"]["nr"])
+        top.addRow(self.tr("Method:"), self.ring_method)
+        top.addRow(self.tr("Sampling NR:"), self.sampling_nr)
+        outer.addLayout(top)
+
+        self.method_stack = QtWidgets.QStackedWidget()
+        self.method_stack.addWidget(self._build_deepcstrd_page())  # index 0
+        self.method_stack.addWidget(self._build_cstrd_page())  # index 1
+        self.method_stack.addWidget(self._build_inbd_page())  # index 2
+        outer.addWidget(self.method_stack)
+        self._on_method_changed()
+        return group
+
+    def _build_cstrd_page(self) -> QtWidgets.QWidget:
+        page = QtWidgets.QWidget()
+        form = QtWidgets.QFormLayout(page)
+        d = self._defaults["cstrd"]
+        self.cstrd_sigma = self._dspin(0.5, 10.0, 0.1, d["sigma"])
+        self.cstrd_th_low = self._dspin(0.0, 255.0, 1.0, d["th_low"])
+        self.cstrd_th_high = self._dspin(0.0, 255.0, 1.0, d["th_high"])
+        self.cstrd_alpha = self._ispin(1, 180, d["alpha"])
+        self.cstrd_nr = self._ispin(36, 720, d["nr"])
+        form.addRow(self.tr("Sigma:"), self.cstrd_sigma)
+        form.addRow(self.tr("Threshold low:"), self.cstrd_th_low)
+        form.addRow(self.tr("Threshold high:"), self.cstrd_th_high)
+        form.addRow(self.tr("Alpha:"), self.cstrd_alpha)
+        form.addRow("nr:", self.cstrd_nr)
+        return page
+
+    def _build_deepcstrd_page(self) -> QtWidgets.QWidget:
+        page = QtWidgets.QWidget()
+        form = QtWidgets.QFormLayout(page)
+        d = self._defaults["deepcstrd"]
+        self.deepcstrd_model = QtWidgets.QComboBox()
+        for model_id, label in _DEEPCSTRD_MODELS:
+            self.deepcstrd_model.addItem(label, model_id)
+        self._select_data(self.deepcstrd_model, d["model"])
+        self.deepcstrd_tile_size = QtWidgets.QComboBox()
+        self.deepcstrd_tile_size.addItem("0 (Full image)", 0)
+        self.deepcstrd_tile_size.addItem("256 (Tiled)", 256)
+        self.deepcstrd_alpha = self._ispin(1, 180, d["alpha"])
+        self.deepcstrd_nr = self._ispin(36, 720, d["nr"])
+        self.deepcstrd_rotations = self._ispin(1, 10, d["rotations"])
+        self.deepcstrd_threshold = self._dspin(0.0, 1.0, 0.01, d["threshold"])
+        self.deepcstrd_width = self._ispin(0, 8192, d["width"])
+        self.deepcstrd_height = self._ispin(0, 8192, d["height"])
+        form.addRow(self.tr("Model:"), self.deepcstrd_model)
+        form.addRow(self.tr("Tile size:"), self.deepcstrd_tile_size)
+        form.addRow(self.tr("Alpha:"), self.deepcstrd_alpha)
+        form.addRow("nr:", self.deepcstrd_nr)
+        form.addRow(self.tr("Rotations:"), self.deepcstrd_rotations)
+        form.addRow(self.tr("Threshold:"), self.deepcstrd_threshold)
+        form.addRow(self.tr("Width:"), self.deepcstrd_width)
+        form.addRow(self.tr("Height:"), self.deepcstrd_height)
+        return page
+
+    def _build_inbd_page(self) -> QtWidgets.QWidget:
+        page = QtWidgets.QWidget()
+        form = QtWidgets.QFormLayout(page)
+        d = self._defaults["inbd"]
+        self.inbd_model = QtWidgets.QComboBox()
+        for model_id, label in _INBD_MODELS:
+            self.inbd_model.addItem(label, model_id)
+        self._select_data(self.inbd_model, d["model"])
+        self.inbd_auto_pith = QtWidgets.QCheckBox(self.tr("Auto-detect pith (INBD)"))
+        self.inbd_auto_pith.setChecked(d["auto_pith"])
+        form.addRow(self.tr("Model:"), self.inbd_model)
+        form.addRow("", self.inbd_auto_pith)
+        return page
+
+    def _build_run_section(self) -> QtWidgets.QWidget:
+        widget = QtWidgets.QWidget()
+        v = QtWidgets.QVBoxLayout(widget)
+        self.progress_bar = QtWidgets.QProgressBar()
+        self.progress_bar.setVisible(False)
+        self.status_label = QtWidgets.QLabel("")
+        buttons = QtWidgets.QHBoxLayout()
+        buttons.addStretch(1)
+        self.run_button = QtWidgets.QPushButton(self.tr("Run"))
+        self.run_button.clicked.connect(self._on_run)
+        self.close_button = QtWidgets.QPushButton(self.tr("Close"))
+        self.close_button.clicked.connect(self.reject)
+        buttons.addWidget(self.run_button)
+        buttons.addWidget(self.close_button)
+        v.addWidget(self.progress_bar)
+        v.addWidget(self.status_label)
+        v.addLayout(buttons)
+        return widget
+
+    # ----- small widget helpers -------------------------------------------
+
+    @staticmethod
+    def _with_button(
+        edit: QtWidgets.QWidget, button: QtWidgets.QWidget
+    ) -> QtWidgets.QWidget:
+        container = QtWidgets.QWidget()
+        row = QtWidgets.QHBoxLayout(container)
+        row.setContentsMargins(0, 0, 0, 0)
+        row.addWidget(edit, stretch=3)
+        row.addWidget(button, stretch=1)
+        return container
+
+    @staticmethod
+    def _dspin(
+        lo: float, hi: float, step: float, value: float
+    ) -> QtWidgets.QDoubleSpinBox:
+        spin = QtWidgets.QDoubleSpinBox()
+        spin.setRange(lo, hi)
+        spin.setSingleStep(step)
+        spin.setValue(value)
+        return spin
+
+    @staticmethod
+    def _ispin(lo: int, hi: int, value: int) -> QtWidgets.QSpinBox:
+        spin = QtWidgets.QSpinBox()
+        spin.setRange(lo, hi)
+        spin.setValue(value)
+        return spin
+
+    @staticmethod
+    def _select_data(
+        combo: QtWidgets.QComboBox, value: Any, by_text: bool = False
+    ) -> None:
+        idx = combo.findText(str(value)) if by_text else combo.findData(value)
+        if idx >= 0:
+            combo.setCurrentIndex(idx)
+
+    def _on_method_changed(self) -> None:
+        method = self.ring_method.currentData()
+        index = {"deepcstrd": 0, "cstrd": 1, "inbd": 2}.get(method, 0)
+        self.method_stack.setCurrentIndex(index)
+
+    # ----- folder picker ---------------------------------------------------
+
+    def _pick_input_dir(self) -> None:
+        directory = QtWidgets.QFileDialog.getExistingDirectory(
+            self, self.tr("Select input folder"), self.input_edit.text()
+        )
+        if directory:
+            self.input_edit.setText(directory)
+
+    # ----- config assembly -------------------------------------------------
+
+    def get_config(self) -> dict[str, Any]:
+        """Assemble a config dict in the schema ``get_detection_params`` reads."""
+        config: dict[str, Any] = {}
+
+        if self.scale_value.value() > 0:
+            config["physical_scale"] = {
+                "value": float(self.scale_value.value()),
+                "unit": self.scale_unit.currentText(),
+            }
+
+        preprocess: dict[str, Any] = {"remove_background": self.remove_bg.isChecked()}
+        if self.resize_scale.value() < 1.0:
+            preprocess["resize_scale"] = float(self.resize_scale.value())
+        config["preprocess"] = preprocess
+
+        config["postprocess"] = {"sampling_nr": int(self.sampling_nr.value())}
+        config["pith"] = {
+            "auto": self.pith_auto.isChecked(),
+            "method": self.pith_method.currentText(),
+        }
+
+        method = self.ring_method.currentData()
+        rings: dict[str, Any] = {"method": method}
+        if method == "cstrd":
+            rings["cstrd"] = {
+                "sigma": float(self.cstrd_sigma.value()),
+                "th_low": float(self.cstrd_th_low.value()),
+                "th_high": float(self.cstrd_th_high.value()),
+                "alpha": int(self.cstrd_alpha.value()),
+                "nr": int(self.cstrd_nr.value()),
+            }
+        elif method == "deepcstrd":
+            rings["deepcstrd"] = {
+                "model": self.deepcstrd_model.currentData(),
+                "tile_size": int(self.deepcstrd_tile_size.currentData()),
+                "alpha": int(self.deepcstrd_alpha.value()),
+                "nr": int(self.deepcstrd_nr.value()),
+                "rotations": int(self.deepcstrd_rotations.value()),
+                "threshold": float(self.deepcstrd_threshold.value()),
+                "width": int(self.deepcstrd_width.value()),
+                "height": int(self.deepcstrd_height.value()),
+            }
+        elif method == "inbd":
+            rings["inbd"] = {
+                "model": self.inbd_model.currentData(),
+                "auto_pith": self.inbd_auto_pith.isChecked(),
+            }
+        config["rings"] = rings
+        return config
+
+    # ----- run lifecycle ---------------------------------------------------
+
+    def _on_run(self) -> None:
+        input_dir = Path(self.input_edit.text().strip())
+        if not input_dir.is_dir():
+            QtWidgets.QMessageBox.warning(
+                self,
+                self.tr("Invalid input"),
+                self.tr("Please select a valid input folder."),
+            )
+            return
+        if not find_images(input_dir):
+            QtWidgets.QMessageBox.warning(
+                self,
+                self.tr("No images"),
+                self.tr("No supported images found in the input folder."),
+            )
+            return
+
+        # Outputs are written into the input folder itself.
+        output_dir = input_dir
+
+        self._save_settings()
+        self._set_running(True)
+
+        self._thread = QtCore.QThread(self)
+        self._worker = BatchWorker(input_dir, output_dir, self.get_config())
+        self._worker.moveToThread(self._thread)
+        self._thread.started.connect(self._worker.run)
+        self._worker.progress.connect(self._on_progress)
+        self._worker.finished.connect(self._on_finished)
+        self._worker.error.connect(self._on_error)
+        self._thread.start()
+
+    def _on_progress(self, current: int, total: int, name: str) -> None:
+        self.progress_bar.setMaximum(total)
+        self.progress_bar.setValue(current)
+        self.status_label.setText(
+            self.tr("Processing %s (%d/%d)") % (name, current, total)
+        )
+
+    def _on_finished(self, summary: BatchSummary) -> None:
+        self._teardown_thread()
+        self._set_running(False)
+        self.status_label.setText(self.tr("Done."))
+        message = self.tr(
+            "Processed: %d\nSkipped (already done): %d\nErrors: %d\n\n"
+            "Summary: %s\nConfig: %s"
+        ) % (
+            summary.processed,
+            summary.skipped,
+            summary.errors,
+            summary.summary_pdf,
+            summary.config_path,
+        )
+        QtWidgets.QMessageBox.information(self, self.tr("Batch complete"), message)
+
+    def _on_error(self, message: str) -> None:
+        self._teardown_thread()
+        self._set_running(False)
+        self.status_label.setText(self.tr("Failed."))
+        QtWidgets.QMessageBox.critical(self, self.tr("Batch failed"), message)
+
+    def _teardown_thread(self) -> None:
+        if self._thread is not None:
+            self._thread.quit()
+            self._thread.wait()
+            self._thread = None
+            self._worker = None
+
+    def _set_running(self, running: bool) -> None:
+        self.run_button.setEnabled(not running)
+        self.progress_bar.setVisible(running)
+        if running:
+            self.progress_bar.setValue(0)
+
+    # ----- settings persistence -------------------------------------------
+
+    def _key(self, name: str) -> str:
+        return f"BatchProcessDialog/{name}"
+
+    def _load_settings(self) -> None:
+        s = self._settings
+        self.scale_value.setValue(s.value(self._key("scale_value"), 0.0, type=float))
+        self._select_data(
+            self.scale_unit,
+            s.value(self._key("scale_unit"), "mm", type=str),
+            by_text=True,
+        )
+        self.resize_scale.setValue(s.value(self._key("resize_scale"), 1.0, type=float))
+        self.remove_bg.setChecked(s.value(self._key("remove_bg"), False, type=bool))
+        self.pith_auto.setChecked(
+            s.value(self._key("pith_auto"), self.pith_auto.isChecked(), type=bool)
+        )
+        self._select_data(
+            self.pith_method,
+            s.value(self._key("pith_method"), self.pith_method.currentText(), type=str),
+            by_text=True,
+        )
+        self._select_data(
+            self.ring_method,
+            s.value(self._key("ring_method"), self.ring_method.currentData(), type=str),
+        )
+        self.sampling_nr.setValue(
+            s.value(self._key("sampling_nr"), self.sampling_nr.value(), type=int)
+        )
+        self._on_method_changed()
+
+    def _save_settings(self) -> None:
+        s = self._settings
+        s.setValue(self._key("scale_value"), float(self.scale_value.value()))
+        s.setValue(self._key("scale_unit"), self.scale_unit.currentText())
+        s.setValue(self._key("resize_scale"), float(self.resize_scale.value()))
+        s.setValue(self._key("remove_bg"), self.remove_bg.isChecked())
+        s.setValue(self._key("pith_auto"), self.pith_auto.isChecked())
+        s.setValue(self._key("pith_method"), self.pith_method.currentText())
+        s.setValue(self._key("ring_method"), self.ring_method.currentData())
+        s.setValue(self._key("sampling_nr"), int(self.sampling_nr.value()))
+
+    def closeEvent(self, event: Any) -> None:
+        self._teardown_thread()
+        super().closeEvent(event)

--- a/uv.lock
+++ b/uv.lock
@@ -3892,7 +3892,7 @@ wheels = [
 
 [[package]]
 name = "tras"
-version = "2.1.5"
+version = "2.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "imgviz" },


### PR DESCRIPTION
Add a folder-wide batch processing feature to the TRAS GUI, splitting the Tools menu into "Single" (the open-image workflow) and "Batch Processing...".

- tras/widgets/batch_dialog.py: BatchProcessDialog configures detection settings inline (optional scale, preprocessing, pith/ring methods + params) and runs detection in a worker thread with a progress bar.
- tras/utils/batch_helper.py: Qt-free run_batch() iterates a folder, writes one .json per image, a combined summary.pdf (one image/page, ring overlay, filename as title), and a CLI-compatible batch_config.yml. Outputs go into the input folder; images that already have a .json are skipped (resumable).
- tras/utils/report_pdf.py: generate_summary_pdf(); _create_ring_overlay_page() gains an optional title.
- tras/utils/cli_config.py: dump_config() YAML writer.
- tras/app.py, tras/widgets/__init__.py: menu restructure + wiring.
- tests: Qt-free coverage for run_batch (outputs, skip-existing, error continuation) and the summary PDF.

Docs: refactor README into a cleaner, user-friendly structure (TOC, fixed heading nesting, updated version refs) and update CLAUDE.md (batch processing, detection-defaults single source of truth).